### PR TITLE
Populate Face Node

### DIFF
--- a/nodes/spatial/spatial_populate_face.py
+++ b/nodes/spatial/spatial_populate_face.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 ###################################################################################
 #
-#  spatial_populate_srf.py
+#  spatial_populate_face.py
 #
 #  Copyright (c) 2022 Ronny Scharf-Wildenhain <ronny.scharf08@gmail.com>
 #
@@ -42,26 +42,28 @@ MAX_ITERATIONS = 1000
 
 
 @register_node
-class PopulateSrf(FCNNodeModel):
+class PopulateFace(FCNNodeModel):
 
     icon: str = icon("nodes_default.png")
-    op_title: str = "Populate (Srf)"
+    op_title: str = "Populate Face"
     op_category: str = "Spatial"
     content_label_objname: str = "fcn_node_bg"
 
     def __init__(self, scene):
         super().__init__(scene=scene,
-                         inputs_init_list=[("Face", True), ("Count", False), ("Radius", False), ("Seed", False)],
-                         outputs_init_list=[("Position", True)])  # , ("Normal", True)])
+                         inputs_init_list=[("Face", True), ("Count", False), ("Distance", False), ("Seed", False)],
+                         outputs_init_list=[("Position", True)])
 
         self.count: int = 10
-        self.radius: float = 1
+        self.radius: float = 0
         self.seed: int = 0
 
         self.grNode.resize(130, 120)
         for socket in self.inputs + self.outputs:
             socket.setSocketPosition()
 
+    ###################################################################################
+    # Based on https://github.com/nortikin/sverchok/blob/master/utils/surface/populate.py
     @staticmethod
     def check_min_radius(new_position: list, old_positions: list, min_radius: float) -> bool:
         if not old_positions:
@@ -114,11 +116,12 @@ class PopulateSrf(FCNNodeModel):
             done += len(good_positions)
 
         return [Vector(coordinates) for coordinates in generated_positions]
+    ###################################################################################
 
     def eval_operation(self, sockets_input_data: list) -> list:
         face: list = sockets_input_data[0] if len(sockets_input_data[0]) > 0 else [None]
         self.count: int = int(sockets_input_data[1][0]) if len(sockets_input_data[1]) > 0 else 10
-        self.radius: float = float(sockets_input_data[2][0]) if len(sockets_input_data[2]) > 0 else 1
+        self.radius: float = float(sockets_input_data[2][0]) if len(sockets_input_data[2]) > 0 else 0
         self.seed: int = int(sockets_input_data[3][0]) if len(sockets_input_data[3]) > 0 else 0
 
         np.random.seed(self.seed)

--- a/package.xml
+++ b/package.xml
@@ -2,8 +2,8 @@
 <package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
   <name>Nodes</name>
   <description>Visual scripting workbench for FreeCAD</description>
-  <version>0.1.5</version>
-  <date>2022-11-15</date>
+  <version>0.1.6</version>
+  <date>2022-11-16</date>
   <maintainer email="ronny.scharf08@gmail.com">Ronny Scharf-Wildenhain</maintainer>
   <license file="LICENSE">LGPLv2.1</license>
   <url type="repository" branch="main">https://github.com/j8sr0230/Nodes</url>
@@ -13,7 +13,7 @@
   <content>
     <workbench>
       <name>Nodes</name>
-      <version>0.1.5</version>
+      <version>0.1.6</version>
       <description>Visual scripting workbench for FreeCAD</description>
       <classname>InitGui</classname>
       <subdirectory>./</subdirectory>


### PR DESCRIPTION
The old Populate (Srf) node used simple UV mapping to map random positions on surfaces, resulting in clumps especially in strong distorted UV regions (see figure).

![old_populate_face](https://user-images.githubusercontent.com/39261150/202186955-42f2f9ab-6268-454a-b9ae-d355bb6db83a.PNG)

The new Populate Face node uses an additional minimum distance between positions to avoid clumping (cf. Blue Noise).

![populate_face](https://user-images.githubusercontent.com/39261150/202187523-78dae6cc-ab11-43c7-8474-972249fbdcab.PNG)

