### PR TITLE
Add required python modules to prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A visual scripting workbench for [FreeCAD](https://www.freecad.org) using
 
 ## Prerequisites
 * FreeCAD >= v0.21
+* python modules: `qtpy`, `awkward`
 
 ## Installation
 Download and install the Nodes workbench via the Addon Manager (**Tools → Addon Manager**).


### PR DESCRIPTION
`qtpy` and `awkward` seem to be required for the Nodes to work as intended.  
This PR just adds them to the “Prerequisites” section of the README.

**Are there any other dependencies?**